### PR TITLE
ci: Add spike to run tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,5 +18,8 @@ jobs:
           submodules: recursive
       - name: Build all tests
         run: |
-          export PATH=$PATH:/riscv/bin
           ./build.sh
+      - name: Run all tests
+        run: |
+          cd build && make test-baremetal-bareMetalC
+

--- a/Containerfile
+++ b/Containerfile
@@ -1,9 +1,25 @@
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV PATH "$PATH:/riscv/bin"
+ENV RISCV "/riscv"
+
 
 RUN apt-get update && \
-    apt-get install autoconf make wget gcc git -y && \
+    apt-get install autoconf make wget gcc git device-tree-compiler build-essential -y && \
     wget https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2024.04.12/riscv64-elf-ubuntu-22.04-gcc-nightly-2024.04.12-nightly.tar.gz && \
     tar -xzvf riscv64-elf-ubuntu-22.04-gcc-nightly-2024.04.12-nightly.tar.gz && \
-    rm -rf riscv64-elf-ubuntu-22.04-gcc-nightly-2024.04.12-nightly.tar.gz
+    rm -rf riscv64-elf-ubuntu-22.04-gcc-nightly-2024.04.12-nightly.tar.gz && \
+    git clone https://github.com/riscv-software-src/riscv-isa-sim.git && \
+    cd riscv-isa-sim && \
+    mkdir build && \
+    cd build && \
+    ../configure --prefix=$RISCV && \
+    make -j$(nproc) && make install && \
+    cd / && \
+    git clone https://github.com/ucb-bar/libgemmini && \
+    cd libgemmini && \
+    make -j$(nproc) && make install
+
+
+


### PR DESCRIPTION
Adds spike and gemmini extensions to docker container and runs all examples in CI

Required for #2

Note: I copied over the apt requirements from the riscv-isa-sim ci, since their installation instructions require boost, but that install didn't work here?